### PR TITLE
Fix/mcp error output schema

### DIFF
--- a/src/mcp/tools/mcpToolRuntime.ts
+++ b/src/mcp/tools/mcpToolRuntime.ts
@@ -242,6 +242,5 @@ export const buildMcpToolErrorResponse = (structuredContent: McpToolStructuredCo
         text: textContent,
       },
     ],
-    structuredContent: structuredContent,
   };
 };

--- a/tests/mcp/tools/fileSystemReadDirectoryTool.test.ts
+++ b/tests/mcp/tools/fileSystemReadDirectoryTool.test.ts
@@ -46,9 +46,9 @@ describe('FileSystemReadDirectoryTool', () => {
           text: JSON.stringify({ errorMessage: `Error: Path must be absolute. Received: ${testPath}` }, null, 2),
         },
       ],
-      structuredContent: {
-        errorMessage: `Error: Path must be absolute. Received: ${testPath}`,
-      },
+      // structuredContent: {
+      //   errorMessage: `Error: Path must be absolute. Received: ${testPath}`,
+      // },
     });
   });
 
@@ -67,9 +67,9 @@ describe('FileSystemReadDirectoryTool', () => {
           text: JSON.stringify({ errorMessage: `Error: Directory not found at path: ${testPath}` }, null, 2),
         },
       ],
-      structuredContent: {
-        errorMessage: `Error: Directory not found at path: ${testPath}`,
-      },
+      // structuredContent: {
+      //   errorMessage: `Error: Directory not found at path: ${testPath}`,
+      // },
     });
   });
 });

--- a/tests/mcp/tools/fileSystemReadFileTool.test.ts
+++ b/tests/mcp/tools/fileSystemReadFileTool.test.ts
@@ -46,9 +46,9 @@ describe('FileSystemReadFileTool', () => {
           text: JSON.stringify({ errorMessage: `Error: Path must be absolute. Received: ${testPath}` }, null, 2),
         },
       ],
-      structuredContent: {
-        errorMessage: `Error: Path must be absolute. Received: ${testPath}`,
-      },
+      // structuredContent: {
+      //   errorMessage: `Error: Path must be absolute. Received: ${testPath}`,
+      // },
     });
   });
 
@@ -67,9 +67,9 @@ describe('FileSystemReadFileTool', () => {
           text: JSON.stringify({ errorMessage: `Error: File not found at path: ${testPath}` }, null, 2),
         },
       ],
-      structuredContent: {
-        errorMessage: `Error: File not found at path: ${testPath}`,
-      },
+      // structuredContent: {
+      //   errorMessage: `Error: File not found at path: ${testPath}`,
+      // },
     });
   });
 });

--- a/tests/mcp/tools/mcpToolRuntime.test.ts
+++ b/tests/mcp/tools/mcpToolRuntime.test.ts
@@ -296,7 +296,7 @@ describe('mcpToolRuntime', () => {
             text: JSON.stringify(errorContent, null, 2),
           },
         ],
-        structuredContent: errorContent,
+        // structuredContent: errorContent,
       });
     });
 
@@ -316,7 +316,7 @@ describe('mcpToolRuntime', () => {
             text: JSON.stringify(errorContent, null, 2),
           },
         ],
-        structuredContent: errorContent,
+        // structuredContent: errorContent,
       });
     });
 


### PR DESCRIPTION
This pull request updates the error response structure in the MCP tool runtime and its related tests. The main change is the removal of the `structuredContent` property from error responses, both in the implementation and in the test expectations.

**Error response structure changes:**

* Removed the `structuredContent` property from the object returned by `buildMcpToolErrorResponse` in `mcpToolRuntime.ts`, so error responses now only include the `text` content.

**Test updates for new error format:**

* Updated tests for `FileSystemReadFileTool` and `FileSystemReadDirectoryTool` to comment out the `structuredContent` property in expected error responses, aligning them with the new response structure. [[1]](diffhunk://#diff-2949805609068ecda0913a56c059d4e302c0d0d71064f915e05890ad3a69aaf2L49-R51) [[2]](diffhunk://#diff-2949805609068ecda0913a56c059d4e302c0d0d71064f915e05890ad3a69aaf2L70-R72) [[3]](diffhunk://#diff-2fdc4a541f7658e1d81625542094f143675c02d697db30a86d57c4ca40d17e3cL49-R51) [[4]](diffhunk://#diff-2fdc4a541f7658e1d81625542094f143675c02d697db30a86d57c4ca40d17e3cL70-R72)
* Updated tests for `mcpToolRuntime` to comment out the `structuredContent` property in error response expectations. [[1]](diffhunk://#diff-1e94aaff32da5820a4567aa01211b1c7d4627540f613061e2a482f254ffa2e08L299-R299) [[2]](diffhunk://#diff-1e94aaff32da5820a4567aa01211b1c7d4627540f613061e2a482f254ffa2e08L319-R319)<!-- Please include a summary of the changes -->

## Checklist

- [x] Run `npm run test`
- [x] Run `npm run lint`